### PR TITLE
Refactor api

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -136,7 +136,7 @@
                 },
                 {
                         "path": "/data_accounting/v1/standard/{action}/{var1}/{var2}/{var3}/{var4}",
-                        "class": "MediaWiki\\Extension\\Example\\RestApiStandard"
+                        "class": "MediaWiki\\Extension\\Example\\StandardRestApi"
                 }
 	],
 	"ResourceFileModulePaths": {

--- a/extension.json
+++ b/extension.json
@@ -135,7 +135,7 @@
                         "class": "MediaWiki\\Extension\\Example\\RestApiDataAccounting_getHash"
                 },
                 {
-                        "path": "/data_accounting/v1/standard/{action}/{var1}/{var2}",
+                        "path": "/data_accounting/v1/standard/{action}/{var1}/{var2}/{var3}/{var4}",
                         "class": "MediaWiki\\Extension\\Example\\RestApiStandard"
                 }
 	],

--- a/extension.json
+++ b/extension.json
@@ -133,6 +133,10 @@
 		{
                         "path": "/data_accounting/v1/request_hash/{rev_id}",
                         "class": "MediaWiki\\Extension\\Example\\RestApiDataAccounting_getHash"
+                },
+                {
+                        "path": "/data_accounting/v1/standard/{action}/{var1}/{var2}",
+                        "class": "MediaWiki\\Extension\\Example\\RestApiStandard"
                 }
 	],
 	"ResourceFileModulePaths": {

--- a/includes/HashWriterHooks.php
+++ b/includes/HashWriterHooks.php
@@ -73,14 +73,14 @@ class HashWriterHooks implements
 			'debug' => $rev->getTimeStamp().'[PV]'.$metadata[0].'[SIG]'.$metadata[1].'[PK]'.$metadata[2]
 		];
 		$dbw->insert('page_verification', $data, __METHOD__);
-		/** re-initilizing variables to ensure they do not hold values for the next revision. */
+                /** re-initilizing variables to ensure they do not hold values for the next revision. */
 		$rev_id =[];
 		$pageContent =[];
 		$contentHash =[];
 		$parentId =[];
 		$metadata =[];
 		$metadataHash =[];
-		$data =[];	
+		$data =[];
 	}
 
 	/**

--- a/includes/RestApiDataAccounting_getHash.php
+++ b/includes/RestApiDataAccounting_getHash.php
@@ -25,12 +25,6 @@ class RestApiDataAccounting_getHash extends SimpleHandler {
         	#$output .= 'Revision[' . $row->rev_id . '] PageVerificationHash[' . $row->hash_verification .']';
 		$output = '[' . $row->hash_verification . ']';
 		}
-
-
-
-		#This code corresponds to the query
-		#SELECT page_verification_id, signature, public_key FROM page_verification WHERE page_verification_id = 55 ORDER BY page_verification_id ASC;
-
 		return $output;
 	}
 

--- a/includes/RestApiDataAccounting_getHash.php
+++ b/includes/RestApiDataAccounting_getHash.php
@@ -22,8 +22,7 @@ class RestApiDataAccounting_getHash extends SimpleHandler {
 
 		$output = '';
 		foreach( $res as $row ) {
-        	#$output .= 'Revision[' . $row->rev_id . '] PageVerificationHash[' . $row->hash_verification .']';
-		$output = '[' . $row->hash_verification . ']';
+        	$output .= 'I sign the following page verification_hash: [0x' . $row->hash_verification .']';
 		}
 		return $output;
 	}

--- a/includes/RestApiStandard.php
+++ b/includes/RestApiStandard.php
@@ -24,7 +24,6 @@ class RestApiStandard extends SimpleHandler {
                         #Expects rev_id as input and returns verification_hash(required), signature(optional), public_key(optional), wallet_address(optiona    l), witness_id(optional)
                         case 'verify_page':
 
-                                /** Database Query */
                                 $lb = MediaWikiServices::getInstance()->getDBLoadBalancer();
                                 $dbr = $lb->getConnectionRef( DB_REPLICA );
                                 $res = $dbr->select(
@@ -34,15 +33,17 @@ class RestApiStandard extends SimpleHandler {
                                 __METHOD__
                                 );
 
-                                $output = '';
+                                $output = array();
                                 foreach( $res as $row ) {
-                                $output = 'Verification Hash: 0x' . $row->hash_verification .' Signature: ' . $row->signature . ' Public_Key: ' . $row->public_key . ' Wallet Address: '  . $row->wallet_address;  
-                                }
-                                return $output;
-                               
-                               # REQUIRED: RETURN AS JSON 
-                               # $output_json = json_encode(foreach ($res as $row); 
-                               # return $output_json;
+                                        $output['rev_id'] = $var1;
+                                        $output['verification_hash'] = $row->hash_verification;
+                                        $output['signature'] = $row->signature;
+                                        $output['public_key'] = $row->public_key;
+                                        $output['wallet_address'] = $row->wallet_address;  
+                                        break;
+                              }
+                              return $output;
+                                #return ['Test'];
 
                         #Expects Revision_ID as input and returns page_title and page_id
                         case 'give_page':

--- a/includes/RestApiStandard.php
+++ b/includes/RestApiStandard.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace MediaWiki\Extension\Example;
+
+use MediaWiki\Rest\SimpleHandler;
+use Wikimedia\ParamValidator\ParamValidator;
+
+/**
+ * Example class to echo a path parameter
+ */
+class RestApiStandard extends SimpleHandler {
+
+	private const VALID_ACTIONS = [ 'reverse', 'shuffle', 'md5' ];
+
+	/** @inheritDoc */
+	public function run( $action, $var1, $var2 ) {
+		switch ( $action ) {
+			case 'reverse':
+				return [ 'echo' => strrev( $var1 ) . $var2 ];
+
+			case 'shuffle':
+				return [ 'echo' => str_shuffle( $var1 ) ];
+
+			case 'md5':
+				return [ 'echo' => md5( $var1 ) ];
+
+			default:
+				return [ ' echo' => $valueToEcho ];
+		}
+	}
+
+	/** @inheritDoc */
+	public function needsWriteAccess() {
+		return false;
+	}
+
+	/** @inheritDoc */
+	public function getParamSettings() {
+		return [
+                        'action' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => self::VALID_ACTIONS,
+				ParamValidator::PARAM_REQUIRED => true,
+			],
+                        'var1' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => true,
+			],
+                        'var2' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => true,
+			],
+		];
+	}
+}
+

--- a/includes/RestApiStandard.php
+++ b/includes/RestApiStandard.php
@@ -11,13 +11,13 @@ use MediaWiki\MediaWikiServices;
  */
 class RestApiStandard extends SimpleHandler {
 
-	private const VALID_ACTIONS = [ 'rev_id', 'give_page', 'page_all_rev', 'page_last_rev', 'page_last_rev_sig', 'page_all_rev_sig', 'page_all_rev_wittness', 'page_all_rev_sig_witness', 'store_sigtx', 'store_witnesstx' ];
+	private const VALID_ACTIONS = [ 'veri_page', 'give_page', 'page_all_rev', 'page_last_rev', 'page_last_rev_sig', 'page_all_rev_sig', 'page_all_rev_wittness', 'page_all_rev_sig_witness', 'store_sigtx', 'store_witnesstx' ];
 
 	/** @inheritDoc */
 	public function run( $action, $var1, $var2, $var3, $var4 ) {
 		switch ( $action ) {
-                        #Expects rev_id: $var1 as input and returns verification_hash(required), signature(optional), public_key(optional), wallet_address(optiona    l), witness_id(optional)
-                        case 'rev_id':
+                        #Expects rev_id as input and returns verification_hash(required), signature(optional), public_key(optional), wallet_address(optiona    l), witness_id(optional)
+                        case 'veri_page':
                                  $lb = MediaWikiServices::getInstance()->getDBLoadBalancer();
                                  $dbr = $lb->getConnectionRef( DB_REPLICA );
  

--- a/includes/RestApiStandard.php
+++ b/includes/RestApiStandard.php
@@ -4,20 +4,35 @@ namespace MediaWiki\Extension\Example;
 
 use MediaWiki\Rest\SimpleHandler;
 use Wikimedia\ParamValidator\ParamValidator;
+use MediaWiki\MediaWikiServices;
 
 /**
- * Example class to echo a path parameter
+ * Extension:DataAccounting Standard Rest API
  */
 class RestApiStandard extends SimpleHandler {
 
-	private const VALID_ACTIONS = [ 'rev_id', 'give_page', 'page_all_rev', 'page_last_rev', 'page_last_rev_sig', 'page_all_rev_sig', 'page_all_rev_wittness', 'page_all_rev_sig_witness' ];
+	private const VALID_ACTIONS = [ 'rev_id', 'give_page', 'page_all_rev', 'page_last_rev', 'page_last_rev_sig', 'page_all_rev_sig', 'page_all_rev_wittness', 'page_all_rev_sig_witness', 'store_sigtx', 'store_witnesstx' ];
 
 	/** @inheritDoc */
-	public function run( $action, $var1, $var2 ) {
+	public function run( $action, $var1, $var2, $var3, $var4 ) {
 		switch ( $action ) {
                         #Expects rev_id: $var1 as input and returns verification_hash(required), signature(optional), public_key(optional), wallet_address(optiona    l), witness_id(optional)
                         case 'rev_id':
-				return [ "Expects rev_id: $var1 as input and returns verification_hash(required), signature(optional), public_key(optional), wallet_address(optional), witness_id(optional) " ];
+                                 $lb = MediaWikiServices::getInstance()->getDBLoadBalancer();
+                                 $dbr = $lb->getConnectionRef( DB_REPLICA );
+ 
+                                 $res = $dbr->select(
+                                'page_verification', 
+                                 [ 'rev_id','hash_verification' ],
+                                 'rev_id = '.$var1,
+                                __METHOD__
+                                );
+ 
+                                $output = '';
+                                foreach( $res as $row ) {
+                                $output .= '0x' . $row->hash_verification .'';
+                                }
+                                return $output;
 
                         #Expects rev_id: $var1 as input and returns page_title and page_id
                         case 'give_page':
@@ -31,7 +46,7 @@ class RestApiStandard extends SimpleHandler {
                         case 'page_last_rev_sig':
 				return [ "Expects page title: $var1 and returns LAST verified and signed revision"];
 
-                        i#Expects page title: $var1 and returns ALL verified revisions
+                        #Expects page title: $var1 and returns ALL verified revisions
                         case 'page_all_rev':
 				return [ "Expects page title: $var1 and returns ALL verified revisions"];
 
@@ -45,6 +60,31 @@ class RestApiStandard extends SimpleHandler {
 
                         #Expects page title: '$var1' and returns ALL verified revisions which have been signed and wittnessed
 			case 'page_all_rev_sig_witness':
+				return [ "Expects page title: $var1 and returns ALL verified revisions which have been signed and wittnessed"];
+
+                                
+                        #Expects Revision_ID [Required] Signature[Required], Public Key[Required] and Wallet Address[Required] as inputs; Returns a status for success or failure
+                        case 'store_sigtx':
+                         /** include functionality to write to database. 
+                         * See https://www.mediawiki.org/wiki/Manual:Database_access */
+                                $lb = MediaWikiServices::getInstance()->getDBLoadBalancer();
+                                $dbw = $lb->getConnectionRef( DB_MASTER );
+                                
+                                $table = 'page_verification';
+                                 
+                                 /** write data to database */
+                                 #$dbw->insert($table ,[$field => $data,$field_two => $data_two], __METHOD__);
+        
+                                 $dbw->update( $table, ['signature' => $var2, 'public_key' => $var3, 'wallet_address' => $var4 ], "rev_id =$var1");
+
+                         return ( "Successfully stored Data for Revision[{$var1}] in Database! Data: Signature[{$var2}], Public_Key[{$var3}] and Wallet_Address[{$var4}] "  );
+                                 $signature=[];
+                                $public_key=[];
+                                $rev_id=[];
+
+
+                        #Expects all requied input for the page_witness database: Transaction Hash, Sender Address, List of Pages with witnessed revision
+			case 'store_witnesstx':
 				return [ "Expects page title: $var1 and returns ALL verified revisions which have been signed and wittnessed"];
 
 			default:
@@ -73,7 +113,17 @@ class RestApiStandard extends SimpleHandler {
                         'var2' => [
 				self::PARAM_SOURCE => 'path',
 				ParamValidator::PARAM_TYPE => 'string',
-				ParamValidator::PARAM_REQUIRED => true,
+				ParamValidator::PARAM_REQUIRED => false,
+			],
+                        'var3' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => false,
+			],
+                        'var4' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => false,
 			],
 		];
 	}

--- a/includes/RestApiStandard.php
+++ b/includes/RestApiStandard.php
@@ -44,7 +44,7 @@ class RestApiStandard extends SimpleHandler {
                                # $output_json = json_encode(foreach ($res as $row); 
                                # return $output_json;
 
-                        #Expects rev_id: $var1 as input and returns page_title and page_id
+                        #Expects Revision_ID as input and returns page_title and page_id
                         case 'give_page':
                                 /** Database Query */ 
                                 $lb = MediaWikiServices::getInstance()->getDBLoadBalancer();
@@ -62,27 +62,78 @@ class RestApiStandard extends SimpleHandler {
                                  }                                    
                                  return $output;
 
-                        #Expects page title: $var1 and returns LAST verified revision
+                        #Expects page title: and returns LAST verified revision
+                        #IMPORTANT: ADD ' ' TO THE PAGE INPUT NAME
+                        #select * from page_verification where page_title = 'Witness' ORDER BY rev_id DESC LIMIT 1;
                         case 'page_last_rev':
-				return [ "Expects page title: $var1 and returns LAST verified revision"];
+                                /** Database Query */
+                                 $lb = MediaWikiServices::getInstance()->getDBLoadBalancer();
+                                 $dbr = $lb->getConnectionRef( DB_REPLICA );
+                                 $res = $dbr->select(
+                                 'page_verification',
+                                 [ 'rev_id','page_title','page_id' ],
+                                 'page_title='.$var1,
+                                 __METHOD__,
+                                 [ 'ORDER BY' => 'rev_id' ] 
+                                  );
 
-                        #Expects page title: $var1 and returns LAST verified and signed revision
+                                 $output = '';
+                                 foreach( $res as $row ) {
+                                 $output = 'Page Title: ' . $row->page_title .' Page_ID: ' . $row->page_id . ' Revision_ID: ' . $row->rev_id;  
+                                 }                                 
+                                 return [$output];
+
+                        #Expects Page Title Name as INPUT and RETURNS LAST signed (and verified) revision.
+                        #POTENTIALLY USELESS AS ALL PAGES GET SIGNED?  
                         case 'page_last_rev_sig':
-				return [ "Expects page title: $var1 and returns LAST verified and signed revision"];
+                                /** Database Query */
+                                 $lb = MediaWikiServices::getInstance()->getDBLoadBalancer();
+                                 $dbr = $lb->getConnectionRef( DB_REPLICA );
+                                 $res = $dbr->select(
+                                 'page_verification',
+                                 [ 'rev_id','page_title','page_id' ],
+                                 'page_title='.$var1,
+                                 __METHOD__,
+                                 [ 'ORDER BY' => 'rev_id' ] 
+                                  );
 
-                        #Expects page title: $var1 and returns ALL verified revisions
+                                 $output = '';
+                                 foreach( $res as $row ) {
+                                 $output = 'Page Title: ' . $row->page_title .' Page_ID: ' . $row->page_id . ' Revision_ID: ' . $row->rev_id;  
+                                 }                                 
+                                 return [$output];
+
+                        #Expects Page Title and returns ALL verified revisions
+                        #NOT IMPLEMENTED
                         case 'page_all_rev':
-				return [ "Expects page title: $var1 and returns ALL verified revisions"];
+                                /** Database Query
+                                 $lb = MediaWikiServices::getInstance()->getDBLoadBalancer();
+                                 $dbr = $lb->getConnectionRef( DB_REPLICA );
+                                 #INSERT LOOP AND PARSE INTO ARRAY TO GET ALL PAGES 
+                                 $res = $dbr->select(
+                                 'page_verification',
+                                 [ 'rev_id','page_title','page_id' ],
+                                 'page_title='.$var1,
+                                 __METHOD__,
+                                 [ 'ORDER BY' => 'rev_id' ] 
+                                  );
 
-                        #Expects page title: $var1 and returns ALL verified revisions which have been signed
+                                 $output = '';
+                                 foreach( $res as $row ) {
+                                 $output = 'Page Title: ' . $row->page_title .' Page_ID: ' . $row->page_id . ' Revision_ID: ' . $row->rev_id;  
+                                 }                                 
+                                 return [$output]; */
+                                return ['NOT IMPLEMENTED'];
+
+                        #Expects Page Title and returns ALL verified revisions which have been signed
 			case 'page_all_rev_sig':
 				return [ "Expects page title: $var1 and returns ALL verified revisions which have been signed"];
 
-                        #Expects page title: $var1 and returns ALL verified revisions which have been witnessed
+                        #Expects Page Title and returns ALL verified revisions which have been witnessed
 			case 'page_all_rev_wittness':
 				return [ "Expects page title: $var1 and returns ALL verified revisions which have been witnessed"];
 
-                        #Expects page title: '$var1' and returns ALL verified revisions which have been signed and wittnessed
+                        #Expects Page Title and returns ALL verified revisions which have been signed and wittnessed
 			case 'page_all_rev_sig_witness':
 				return [ "Expects page title: $var1 and returns ALL verified revisions which have been signed and wittnessed"];
 
@@ -107,12 +158,12 @@ class RestApiStandard extends SimpleHandler {
                                 $rev_id=[];
 
 
-                        #Expects all requied input for the page_witness database: Transaction Hash, Sender Address, List of Pages with witnessed revision
+                        #Expects all required input for the page_witness database: Transaction Hash, Sender Address, List of Pages with witnessed revision
 			case 'store_witnesstx':
 				return [ "Expects page title: $var1 and returns ALL verified revisions which have been signed and wittnessed"];
 
 			default:
-				return [ ' echo' => $valueToEcho ];
+				return [ 'HIT ACTION DEFAULT - EXIT' ];
 		}
 	}
 

--- a/includes/RestApiStandard.php
+++ b/includes/RestApiStandard.php
@@ -69,13 +69,14 @@ class RestApiStandard extends SimpleHandler {
                         #select * from page_verification where page_title = 'Witness' ORDER BY rev_id DESC LIMIT 1;
                         #POTENTIALLY USELESS AS ALL PAGES GET VERIFIED?  
                         case 'page_last_rev':
+                                $page_title = $var1;
                                 /** Database Query */
                                  $lb = MediaWikiServices::getInstance()->getDBLoadBalancer();
                                  $dbr = $lb->getConnectionRef( DB_REPLICA );
                                  $res = $dbr->select(
                                  'page_verification',
                                  [ 'rev_id','page_title','page_id' ],
-                                 'page_title='.$var1,
+                                 'page_title= \''.$page_title.'\'',
                                  __METHOD__,
                                  [ 'ORDER BY' => 'rev_id' ] 
                                   );
@@ -109,6 +110,7 @@ class RestApiStandard extends SimpleHandler {
                         #Expects Page Title and returns ALL verified revisions
                         #NOT IMPLEMENTED
                         case 'page_all_rev':
+                                $page_title = $var1;
                                 //Database Query
                                  $lb = MediaWikiServices::getInstance()->getDBLoadBalancer();
                                  $dbr = $lb->getConnectionRef( DB_REPLICA );
@@ -116,17 +118,22 @@ class RestApiStandard extends SimpleHandler {
                                  $res = $dbr->select(
                                  'page_verification',
                                  [ 'rev_id','page_title','page_id' ],
-                                 'page_title='.$var1,
+                                 'page_title= \''.$page_title.'\'',
                                  __METHOD__,
                                  [ 'ORDER BY' => 'rev_id' ] 
                                   );
 
-                                 $output = '';
+                                 $output = array();
+                                 $count = 0;
                                  foreach( $res as $row ) {
-                                 $output = 'Page Title: ' . $row->page_title .' Page_ID: ' . $row->page_id . ' Revision_ID: ' . $row->rev_id;  
+                                     $data = array();
+                                     $data['page_title'] = $row->page_title;
+                                     $data['page_id'] = $row->page_id;
+                                     $data['rev_id'] = $row->rev_id;
+                                 $output[$count] = $data;
+                                 $count ++;
                                  }                                 
-                                 return [$output];
-                                return ['NOT IMPLEMENTED'];
+                                 return $output;
 
                         #Expects Page Title and returns ALL verified revisions which have been signed
 			case 'page_all_rev_sig':
@@ -161,7 +168,7 @@ class RestApiStandard extends SimpleHandler {
                                     [
                                         'signature' => $signature, 
                                         'public_key' => $public_key, 
-                                        'wallet_address' => $wallet_address;
+                                        'wallet_address' => $wallet_address,
                                     ], 
                                     "rev_id =$rev_id");
 

--- a/includes/RestApiStandard.php
+++ b/includes/RestApiStandard.php
@@ -16,13 +16,13 @@ ini_set("display_errors", 1);
  */
 class RestApiStandard extends SimpleHandler {
 
-	private const VALID_ACTIONS = [ 'veri_page', 'give_page', 'page_all_rev', 'page_last_rev', 'page_last_rev_sig', 'page_all_rev_sig', 'page_all_rev_wittness', 'page_all_rev_sig_witness', 'store_sigtx', 'store_witnesstx' ];
+	private const VALID_ACTIONS = [ 'verify_page', 'give_page', 'page_all_rev', 'page_last_rev', 'page_last_rev_sig', 'page_all_rev_sig', 'page_all_rev_wittness', 'page_all_rev_sig_witness', 'store_sigtx', 'store_witnesstx' ];
 
 	/** @inheritDoc */
 	public function run( $action, $var1, $var2, $var3, $var4 ) {
 		switch ( $action ) {
                         #Expects rev_id as input and returns verification_hash(required), signature(optional), public_key(optional), wallet_address(optiona    l), witness_id(optional)
-                        case 'veri_page':
+                        case 'verify_page':
 
                                 /** Database Query */
                                 $lb = MediaWikiServices::getInstance()->getDBLoadBalancer();
@@ -62,9 +62,10 @@ class RestApiStandard extends SimpleHandler {
                                  }                                    
                                  return $output;
 
-                        #Expects page title: and returns LAST verified revision
+                        #Expects Page Title and returns LAST verified revision
                         #IMPORTANT: ADD ' ' TO THE PAGE INPUT NAME
                         #select * from page_verification where page_title = 'Witness' ORDER BY rev_id DESC LIMIT 1;
+                        #POTENTIALLY USELESS AS ALL PAGES GET VERIFIED?  
                         case 'page_last_rev':
                                 /** Database Query */
                                  $lb = MediaWikiServices::getInstance()->getDBLoadBalancer();
@@ -84,22 +85,22 @@ class RestApiStandard extends SimpleHandler {
                                  return [$output];
 
                         #Expects Page Title Name as INPUT and RETURNS LAST signed (and verified) revision.
-                        #POTENTIALLY USELESS AS ALL PAGES GET SIGNED?  
+                        #Does not work as expected - Shows signature but also shows the query if no signature is there.
                         case 'page_last_rev_sig':
                                 /** Database Query */
                                  $lb = MediaWikiServices::getInstance()->getDBLoadBalancer();
                                  $dbr = $lb->getConnectionRef( DB_REPLICA );
                                  $res = $dbr->select(
                                  'page_verification',
-                                 [ 'rev_id','page_title','page_id' ],
+                                 [ 'rev_id','page_title','signature' ],
                                  'page_title='.$var1,
                                  __METHOD__,
-                                 [ 'ORDER BY' => 'rev_id' ] 
+                                 [ 'ORDER BY' => 'signature' ] 
                                   );
 
                                  $output = '';
                                  foreach( $res as $row ) {
-                                 $output = 'Page Title: ' . $row->page_title .' Page_ID: ' . $row->page_id . ' Revision_ID: ' . $row->rev_id;  
+                                 $output = 'Page Title: ' . $row->page_title .' Signature: ' . $row->signature . ' Revision_ID: ' . $row->rev_id;  
                                  }                                 
                                  return [$output];
 
@@ -127,16 +128,15 @@ class RestApiStandard extends SimpleHandler {
 
                         #Expects Page Title and returns ALL verified revisions which have been signed
 			case 'page_all_rev_sig':
-				return [ "Expects page title: $var1 and returns ALL verified revisions which have been signed"];
+                                return ['NOT IMPLEMENTED'];
 
                         #Expects Page Title and returns ALL verified revisions which have been witnessed
 			case 'page_all_rev_wittness':
-				return [ "Expects page title: $var1 and returns ALL verified revisions which have been witnessed"];
+                                return ['NOT IMPLEMENTED'];
 
                         #Expects Page Title and returns ALL verified revisions which have been signed and wittnessed
 			case 'page_all_rev_sig_witness':
-				return [ "Expects page title: $var1 and returns ALL verified revisions which have been signed and wittnessed"];
-
+                                return ['NOT IMPLEMENTED'];
                                 
                         #Expects Revision_ID [Required] Signature[Required], Public Key[Required] and Wallet Address[Required] as inputs; Returns a status for success or failure
                         case 'store_sigtx':

--- a/includes/RestApiStandard.php
+++ b/includes/RestApiStandard.php
@@ -16,12 +16,31 @@ ini_set("display_errors", 1);
  */
 class RestApiStandard extends SimpleHandler {
 
-	private const VALID_ACTIONS = [ 'verify_page', 'give_page', 'page_all_rev', 'page_last_rev', 'page_last_rev_sig', 'page_all_rev_sig', 'page_all_rev_wittness', 'page_all_rev_sig_witness', 'store_signed_tx', 'store_witnesstx' ];
+	private const VALID_ACTIONS = ['help', 'verify_page', 'get_page_by_rev_id', 'page_all_rev', 'page_last_rev', 'page_last_rev_sig', 'page_all_rev_sig', 'page_all_rev_wittness', 'page_all_rev_sig_witness', 'store_signed_tx', 'store_witnesstx' ];
 
 	/** @inheritDoc */
 	public function run( $action, $var1, $var2, $var3, $var4 ) {
 		switch ( $action ) {
-                        #Expects rev_id as input and returns verification_hash(required), signature(optional), public_key(optional), wallet_address(optiona    l), witness_id(optional)
+                        #Expects rev_id as input and returns verification_hash(required), signature(optional), public_key(optional), wallet_address(optional), witness_id(optional)
+        case 'help':
+            $index = (int) $var1;
+            $output = array();
+            $output[0]=["help expects an number as in input to displays information for all actions this API services.To use an action, replace 'help' in your url with your desired action. ensure you provide all four '\' as they are the separators for up to four input variables. actions: help[0], verify_page[1], get_page_by_rev_id[2], page_last_rev[3], page_last_rev_sig[4], page_all_rev[5], page_all_rev_sig[6], page_all_rev_wittness[7], page_all_rev_sig_witness[8], store_signed_tx[9], store_witness_tx[10]"];
+            $output[1]=['action \'verify_page\': expects revision_id as input and returns verification_hash(required), signature(optional), public_key(optional), wallet_address(optional), witness_id(optional)'];
+            $output[2]=['action \'get_page_by_rev_id\': expects revision_id as input and returns page_title and page_id'];
+            $output[3]=['action \'page_last_rev\': expects page_title and returns last verified revision.'];
+            $output[4]=['action \'page_lage_rev_sig\': expects page_title as input and returns last signed and verified revision_id.'];
+            $output[5]=['action \'page_all_rev\': expects page_title as input and returns last signed and verified revision_id.'];
+            $output[6]=['action \'page_all_rev_sig\':NOT IMPLEMENTED'];
+            $output[7]=['action \'page_all_rev_witness\':NOT IMPLEMENTED'];
+            $output[8]=['action \'page_all_rev_sig_witness\':NOT IMPLEMENTED'];
+            $output[9]=['action \'store_signed_tx\':expects revision_id=value1 [required] signature=value2[required], public_key=value3[required] and wallet_address=value4[required] as inputs; Returns a status for success or failure
+'];
+            $output[10]=['action \'store_witness_tx\':NOT IMPLEMENTED'];
+
+
+                   return $output[$index];
+
                         case 'verify_page':
 
                                 $rev_id = $var1;
@@ -46,8 +65,8 @@ class RestApiStandard extends SimpleHandler {
                               }
                               return $output;
 
-                        #Expects Revision_ID as input and returns page_title and page_id
-                        case 'give_page':
+                       #Expects Revision_ID as input and returns page_title and page_id
+                        case 'get_page_by_rev_id':
                                 /** Database Query */ 
                                 $lb = MediaWikiServices::getInstance()->getDBLoadBalancer();
                                 $dbr = $lb->getConnectionRef( DB_REPLICA );
@@ -65,7 +84,6 @@ class RestApiStandard extends SimpleHandler {
                                  return $output;
 
                         #Expects Page Title and returns LAST verified revision
-                        #IMPORTANT: ADD ' ' TO THE PAGE INPUT NAME
                         #select * from page_verification where page_title = 'Witness' ORDER BY rev_id DESC LIMIT 1;
                         #POTENTIALLY USELESS AS ALL PAGES GET VERIFIED?  
                         case 'page_last_rev':
@@ -90,13 +108,15 @@ class RestApiStandard extends SimpleHandler {
                         #Expects Page Title Name as INPUT and RETURNS LAST signed (and verified) revision.
                         #Does not work as expected - Shows signature but also shows the query if no signature is there.
                         case 'page_last_rev_sig':
+                            #select * from page_verification where page_title='Main Page' AND signature <> '' ORDER BY rev_id DESC;
+                                $page_title = $var1;
                                 /** Database Query */
                                  $lb = MediaWikiServices::getInstance()->getDBLoadBalancer();
                                  $dbr = $lb->getConnectionRef( DB_REPLICA );
                                  $res = $dbr->select(
                                  'page_verification',
                                  [ 'rev_id','page_title','signature' ],
-                                 'page_title='.$var1,
+                                 'page_title=\''.$page_title.'\'',
                                  __METHOD__,
                                  [ 'ORDER BY' => 'signature' ] 
                                   );
@@ -179,7 +199,7 @@ class RestApiStandard extends SimpleHandler {
                                 $rev_id=[];
 
                         #Expects all required input for the page_witness database: Transaction Hash, Sender Address, List of Pages with witnessed revision
-			case 'store_witnesstx':
+			case 'store_witness_tx':
 				return [ "Expects page title: $var1 and returns ALL verified revisions which have been signed and wittnessed"];
 
 			default:

--- a/includes/RestApiStandard.php
+++ b/includes/RestApiStandard.php
@@ -10,19 +10,42 @@ use Wikimedia\ParamValidator\ParamValidator;
  */
 class RestApiStandard extends SimpleHandler {
 
-	private const VALID_ACTIONS = [ 'reverse', 'shuffle', 'md5' ];
+	private const VALID_ACTIONS = [ 'rev_id', 'give_page', 'page_all_rev', 'page_last_rev', 'page_last_rev_sig', 'page_all_rev_sig', 'page_all_rev_wittness', 'page_all_rev_sig_witness' ];
 
 	/** @inheritDoc */
 	public function run( $action, $var1, $var2 ) {
 		switch ( $action ) {
-			case 'reverse':
-				return [ 'echo' => strrev( $var1 ) . $var2 ];
+                        #Expects rev_id: $var1 as input and returns verification_hash(required), signature(optional), public_key(optional), wallet_address(optiona    l), witness_id(optional)
+                        case 'rev_id':
+				return [ "Expects rev_id: $var1 as input and returns verification_hash(required), signature(optional), public_key(optional), wallet_address(optional), witness_id(optional) " ];
 
-			case 'shuffle':
-				return [ 'echo' => str_shuffle( $var1 ) ];
+                        #Expects rev_id: $var1 as input and returns page_title and page_id
+                        case 'give_page':
+				return [ "Expects rev_id: $var1 as input and returns page_title and page_id" ];
 
-			case 'md5':
-				return [ 'echo' => md5( $var1 ) ];
+                        #Expects page title: $var1 and returns LAST verified revision
+                        case 'page_last_rev':
+				return [ "Expects page title: $var1 and returns LAST verified revision"];
+
+                        #Expects page title: $var1 and returns LAST verified and signed revision
+                        case 'page_last_rev_sig':
+				return [ "Expects page title: $var1 and returns LAST verified and signed revision"];
+
+                        i#Expects page title: $var1 and returns ALL verified revisions
+                        case 'page_all_rev':
+				return [ "Expects page title: $var1 and returns ALL verified revisions"];
+
+                        #Expects page title: $var1 and returns ALL verified revisions which have been signed
+			case 'page_all_rev_sig':
+				return [ "Expects page title: $var1 and returns ALL verified revisions which have been signed"];
+
+                        #Expects page title: $var1 and returns ALL verified revisions which have been witnessed
+			case 'page_all_rev_wittness':
+				return [ "Expects page title: $var1 and returns ALL verified revisions which have been witnessed"];
+
+                        #Expects page title: '$var1' and returns ALL verified revisions which have been signed and wittnessed
+			case 'page_all_rev_sig_witness':
+				return [ "Expects page title: $var1 and returns ALL verified revisions which have been signed and wittnessed"];
 
 			default:
 				return [ ' echo' => $valueToEcho ];

--- a/includes/StandardRestApi.php
+++ b/includes/StandardRestApi.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace MediaWiki\Extension\Example;
+
+use MediaWiki\Rest\SimpleHandler;
+use Wikimedia\ParamValidator\ParamValidator;
+use MediaWiki\MediaWikiServices;
+
+# include / exclude for debugging
+error_reporting(E_ALL);
+ini_set("display_errors", 1);
+
+
+/**
+ * Extension:DataAccounting Standard Rest API
+ */
+class StandardRestApi extends SimpleHandler {
+
+	private const VALID_ACTIONS = ['help', 'verify_page', 'get_page_by_rev_id', 'page_all_rev', 'page_last_rev', 'page_last_rev_sig', 'page_all_rev_sig', 'page_all_rev_wittness', 'page_all_rev_sig_witness', 'store_signed_tx', 'store_witnesstx' ];
+
+	/** @inheritDoc */
+	public function run( $action, $var1, $var2, $var3, $var4 ) {
+		switch ( $action ) {
+                        #Expects rev_id as input and returns verification_hash(required), signature(optional), public_key(optional), wallet_address(optional), witness_id(optional)
+        case 'help':
+            $index = (int) $var1;
+            $output = array();
+            $output[0]=["help expects an number as in input to displays information for all actions this API services.To use an action, replace 'help' in your url with your desired action. ensure you provide all four '\' as they are the separators for up to four input variables. actions: help[0], verify_page[1], get_page_by_rev_id[2], page_last_rev[3], page_last_rev_sig[4], page_all_rev[5], page_all_rev_sig[6], page_all_rev_wittness[7], page_all_rev_sig_witness[8], store_signed_tx[9], store_witness_tx[10]"];
+            $output[1]=['action \'verify_page\': expects revision_id as input and returns verification_hash(required), signature(optional), public_key(optional), wallet_address(optional), witness_id(optional)'];
+            $output[2]=['action \'get_page_by_rev_id\': expects revision_id as input and returns page_title and page_id'];
+            $output[3]=['action \'page_last_rev\': expects page_title and returns last verified revision.'];
+            $output[4]=['action \'page_lage_rev_sig\': expects page_title as input and returns last signed and verified revision_id.'];
+            $output[5]=['action \'page_all_rev\': expects page_title as input and returns last signed and verified revision_id.'];
+            $output[6]=['action \'page_all_rev_sig\':NOT IMPLEMENTED'];
+            $output[7]=['action \'page_all_rev_witness\':NOT IMPLEMENTED'];
+            $output[8]=['action \'page_all_rev_sig_witness\':NOT IMPLEMENTED'];
+            $output[9]=['action \'store_signed_tx\':expects revision_id=value1 [required] signature=value2[required], public_key=value3[required] and wallet_address=value4[required] as inputs; Returns a status for success or failure
+'];
+            $output[10]=['action \'store_witness_tx\':NOT IMPLEMENTED'];
+
+
+                   return $output[$index];
+
+                        case 'verify_page':
+
+                                $rev_id = $var1;
+
+                                $lb = MediaWikiServices::getInstance()->getDBLoadBalancer();
+                                $dbr = $lb->getConnectionRef( DB_REPLICA );
+                                $res = $dbr->select(
+                                'page_verification', 
+                                 [ 'rev_id','hash_verification','signature','public_key','wallet_address' ],
+                                 'rev_id = '.$var1,
+                                __METHOD__
+                                );
+
+                                $output = array();
+                                foreach( $res as $row ) {
+                                        $output['rev_id'] = $rev_id;
+                                        $output['verification_hash'] = $row->hash_verification;
+                                        $output['signature'] = $row->signature;
+                                        $output['public_key'] = $row->public_key;
+                                        $output['wallet_address'] = $row->wallet_address;  
+                                        break;
+                              }
+                              return $output;
+
+                       #Expects Revision_ID as input and returns page_title and page_id
+                        case 'get_page_by_rev_id':
+                                /** Database Query */ 
+                                $lb = MediaWikiServices::getInstance()->getDBLoadBalancer();
+                                $dbr = $lb->getConnectionRef( DB_REPLICA );
+                                $res = $dbr->select(
+                                'page_verification',
+                                 [ 'rev_id','page_title','page_id' ],
+                                 'rev_id = '.$var1,
+                                 __METHOD__
+                                 );
+                                                                   
+                                 $output = '';
+                                 foreach( $res as $row ) {
+                                        $output = 'Page Title: ' . $row->page_title .' Page_ID: ' . $row->page_id;  
+                                 }                                    
+                                 return $output;
+
+                        #Expects Page Title and returns LAST verified revision
+                        #select * from page_verification where page_title = 'Witness' ORDER BY rev_id DESC LIMIT 1;
+                        #POTENTIALLY USELESS AS ALL PAGES GET VERIFIED?  
+                        case 'page_last_rev':
+                                $page_title = $var1;
+                                /** Database Query */
+                                 $lb = MediaWikiServices::getInstance()->getDBLoadBalancer();
+                                 $dbr = $lb->getConnectionRef( DB_REPLICA );
+                                 $res = $dbr->select(
+                                 'page_verification',
+                                 [ 'rev_id','page_title','page_id' ],
+                                 'page_title= \''.$page_title.'\'',
+                                 __METHOD__,
+                                 [ 'ORDER BY' => 'rev_id' ] 
+                                  );
+
+                                 $output = '';
+                                 foreach( $res as $row ) {
+                                 $output = 'Page Title: ' . $row->page_title .' Page_ID: ' . $row->page_id . ' Revision_ID: ' . $row->rev_id;  
+                                 }                                 
+                                 return [$output];
+
+                        #Expects Page Title Name as INPUT and RETURNS LAST signed (and verified) revision.
+                        #Does not work as expected - Shows signature but also shows the query if no signature is there.
+                        case 'page_last_rev_sig':
+                            #select * from page_verification where page_title='Main Page' AND signature <> '' ORDER BY rev_id DESC;
+                                $page_title = $var1;
+                                /** Database Query */
+                                 $lb = MediaWikiServices::getInstance()->getDBLoadBalancer();
+                                 $dbr = $lb->getConnectionRef( DB_REPLICA );
+                                 $res = $dbr->select(
+                                 'page_verification',
+                                 [ 'rev_id','page_title','signature' ],
+                                 'page_title=\''.$page_title.'\'',
+                                 __METHOD__,
+                                 [ 'ORDER BY' => 'signature' ] 
+                                  );
+
+                                 $output = '';
+                                 foreach( $res as $row ) {
+                                 $output = 'Page Title: ' . $row->page_title .' Signature: ' . $row->signature . ' Revision_ID: ' . $row->rev_id;  
+                                 }                                 
+                                 return [$output];
+
+                        #Expects Page Title and returns ALL verified revisions
+                        #NOT IMPLEMENTED
+                        case 'page_all_rev':
+                                $page_title = $var1;
+                                //Database Query
+                                 $lb = MediaWikiServices::getInstance()->getDBLoadBalancer();
+                                 $dbr = $lb->getConnectionRef( DB_REPLICA );
+                                 #INSERT LOOP AND PARSE INTO ARRAY TO GET ALL PAGES 
+                                 $res = $dbr->select(
+                                 'page_verification',
+                                 [ 'rev_id','page_title','page_id' ],
+                                 'page_title= \''.$page_title.'\'',
+                                 __METHOD__,
+                                 [ 'ORDER BY' => 'rev_id' ] 
+                                  );
+
+                                 $output = array();
+                                 $count = 0;
+                                 foreach( $res as $row ) {
+                                     $data = array();
+                                     $data['page_title'] = $row->page_title;
+                                     $data['page_id'] = $row->page_id;
+                                     $data['rev_id'] = $row->rev_id;
+                                 $output[$count] = $data;
+                                 $count ++;
+                                 }                                 
+                                 return $output;
+
+                        #Expects Page Title and returns ALL verified revisions which have been signed
+			case 'page_all_rev_sig':
+                                return ['NOT IMPLEMENTED'];
+
+                        #Expects Page Title and returns ALL verified revisions which have been witnessed
+			case 'page_all_rev_wittness':
+                                return ['NOT IMPLEMENTED'];
+
+                        #Expects Page Title and returns ALL verified revisions which have been signed and wittnessed
+			case 'page_all_rev_sig_witness':
+                                return ['NOT IMPLEMENTED'];
+                                
+                        #Expects Revision_ID [Required] Signature[Required], Public Key[Required] and Wallet Address[Required] as inputs; Returns a status for success or failure
+                        case 'store_signed_tx':
+                         /** include functionality to write to database. 
+                         * See https://www.mediawiki.org/wiki/Manual:Database_access */
+                            $rev_id = $var1;
+                            $signature = $var2;
+                            $public_key = $var3;
+                            $wallet_address = $var4;
+
+                                $lb = MediaWikiServices::getInstance()->getDBLoadBalancer();
+                                $dbw = $lb->getConnectionRef( DB_MASTER );
+                                
+                                $table = 'page_verification';
+                                 
+                                 /** write data to database */
+                                 #$dbw->insert($table ,[$field => $data,$field_two => $data_two], __METHOD__);
+        
+                                $dbw->update( $table, 
+                                    [
+                                        'signature' => $signature, 
+                                        'public_key' => $public_key, 
+                                        'wallet_address' => $wallet_address,
+                                    ], 
+                                    "rev_id =$rev_id");
+
+                         return ( "Successfully stored Data for Revision[{$var1}] in Database! Data: Signature[{$var2}], Public_Key[{$var3}] and Wallet_Address[{$var4}] "  );
+                                 $signature=[];
+                                $public_key=[];
+                                $wallet_address=[];
+                                $rev_id=[];
+
+                        #Expects all required input for the page_witness database: Transaction Hash, Sender Address, List of Pages with witnessed revision
+			case 'store_witness_tx':
+				return [ "Expects page title: $var1 and returns ALL verified revisions which have been signed and wittnessed"];
+
+			default:
+				return [ 'HIT ACTION DEFAULT - EXIT' ];
+		}
+	}
+
+	/** @inheritDoc */
+	public function needsWriteAccess() {
+		return false;
+	}
+
+	/** @inheritDoc */
+	public function getParamSettings() {
+		return [
+                        'action' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => self::VALID_ACTIONS,
+				ParamValidator::PARAM_REQUIRED => true,
+			],
+                        'var1' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => true,
+			],
+                        'var2' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => false,
+			],
+                        'var3' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => false,
+			],
+                        'var4' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => false,
+			],
+		];
+	}
+}
+


### PR DESCRIPTION
#21 #8 #19 

I refactored the API (RestApiStandard.php) which can be called via http://localhost:9352/rest.php/data_accounting/v1/standard/help/0///

Important the '///' in the end are required and are separators for up to 4 input values for each 'action call' the actions can be listed by just calling the link on top which provides you with a help page for how to use the API.